### PR TITLE
style: change <hr/> to <hr>

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -13,7 +13,7 @@ These are HTML strings. As part of the course, you'll be using JavaScript functi
 replace the %data% placeholder text you see in them.
 */
 var HTMLheaderName = '<h1 id="name">%data%</h1>';
-var HTMLheaderRole = '<span>%data%</span><hr/>';
+var HTMLheaderRole = '<span>%data%</span><hr>';
 
 var HTMLcontactGeneric = '<li class="flex-item"><span class="orange-text">%contact%</span><span class="white-text">%data%</span></li>';
 var HTMLmobile = '<li class="flex-item"><span class="orange-text">mobile</span><span class="white-text">%data%</span></li>';


### PR DESCRIPTION
I am taking JavaScript Basics course and saw a &lt;hr/&gt; in the helper.js file. I think it should be better to use &lt;hr&gt; according to "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr", so I made this change.