### PR TITLE
Fix for-in Loop Issue

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -131,13 +131,13 @@ function initializeMap() {
     // iterates through school locations and appends each location to
     // the locations array
     education.schools.forEach(function(school){
-      location.push(school.location);
+      locations.push(school.location);
     });
 
     // iterates through work locations and appends each location to
     // the locations array
     work.jobs.forEach(function(job){
-      location.push(job.location);
+      locations.push(job.location);
     });
 
     return locations;

--- a/js/helper.js
+++ b/js/helper.js
@@ -130,15 +130,15 @@ function initializeMap() {
 
     // iterates through school locations and appends each location to
     // the locations array
-    for (var school in education.schools) {
-      locations.push(education.schools[school].location);
-    }
+    education.schools.forEach(function(school){
+      location.push(school.location);
+    });
 
     // iterates through work locations and appends each location to
     // the locations array
-    for (var job in work.jobs) {
-      locations.push(work.jobs[job].location);
-    }
+    work.jobs.forEach(function(job){
+      location.push(job.location);
+    });
 
     return locations;
   }


### PR DESCRIPTION
The code style is not right, the issue is related to **for-in loop** section in JavaScript Language Rules subsection in the [JavaScript Style Guide](http://udacity.github.io/frontend-nanodegree-styleguide/javascript.html). The `for-in` loop should only be used for iterating over keys in an object/map/hash.

`for-in` loops are often incorrectly used to loop over the elements in an array. This is however very error prone because it does not loop from `0` to `length - 1` but over all the present keys in the object and its prototype chain.

Therefore, the code snippet blow is incorrect,

```
    for (var school in education.schools) {
      locations.push(education.schools[school].location);
    }
```

The correct way to do the iteration is code below,

```
    education.schools.forEach(function(school){
      locations.push(school.location);
    });
```

### This has to be changed!

Students always refer to this file while implementing the `resumeBuilder.js`. 90% of the student using `for-in` loop in their project implementation because of this sample file.