### PR TITLE
 fix: map content overflowing on small viewports

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -200,8 +200,11 @@ span {
   margin: 0 5%;
 }
 
-#mapDiv {
+#map-container {
   height: 400px;
+}
+
+#mapDiv {
   width: 100%;
   padding-bottom: 5%;
 }

--- a/js/helper.js
+++ b/js/helper.js
@@ -56,8 +56,9 @@ var HTMLonlineDates = '<div class="date-text">%data%</div>';
 var HTMLonlineURL = '<br><a href="#">%data%</a>';
 
 var internationalizeButton = '<button>Internationalize</button>';
-var googleMap = '<div id="map"></div>';
 
+// map-container keeps map from overflowing on small viewports (e.g., 320px, iPhone 5)
+var googleMap = '<div id="map-container"><div id="map"></div></div>';
 
 /*
 The International Name challenge in Lesson 2 where you'll create a function that will need this helper code to run. Don't delete! It hooks up your code to the button you'll be appending.
@@ -65,7 +66,7 @@ The International Name challenge in Lesson 2 where you'll create a function that
 $(document).ready(function() {
   $('button').click(function() {
     var iName = inName() || function(){};
-    $('#name').html(iName);  
+    $('#name').html(iName);
   });
 });
 
@@ -109,9 +110,9 @@ function initializeMap() {
     disableDefaultUI: true
   };
 
-  /* 
+  /*
   For the map to be displayed, the googleMap var must be
-  appended to #mapDiv in resumeBuilder.js. 
+  appended to #mapDiv in resumeBuilder.js.
   */
   map = new google.maps.Map(document.querySelector('#map'), mapOptions);
 
@@ -130,7 +131,7 @@ function initializeMap() {
 
     // iterates through school locations and appends each location to
     // the locations array. Note that forEach is used for array iteration
-    // as described in the Udacity FEND Style Guide: 
+    // as described in the Udacity FEND Style Guide:
     // https://udacity.github.io/frontend-nanodegree-styleguide/javascript.html#for-in-loop
     education.schools.forEach(function(school){
       locations.push(school.location);
@@ -138,7 +139,7 @@ function initializeMap() {
 
     // iterates through work locations and appends each location to
     // the locations array. Note that forEach is used for array iteration
-    // as described in the Udacity FEND Style Guide: 
+    // as described in the Udacity FEND Style Guide:
     // https://udacity.github.io/frontend-nanodegree-styleguide/javascript.html#for-in-loop
     work.jobs.forEach(function(job){
       locations.push(job.location);


### PR DESCRIPTION
On small viewports (e.g., 320px, iPhone 5) the map was overflowing
and covering the "Let's Connect" message.  Add container div for map
with height of 400px.  Change height of mapDiv to default setting
(auto) to allow room on small viewports for header text and the map.