### PR TITLE
Make internationlize button call inName with argument

### DIFF
--- a/js/helper.js
+++ b/js/helper.js
@@ -64,8 +64,9 @@ The International Name challenge in Lesson 2 where you'll create a function that
 */
 $(document).ready(function() {
   $('button').click(function() {
-    var iName = inName() || function(){};
-    $('#name').html(iName);  
+    var $name = $('#name');
+    var iName = inName($name.text()) || function(){};
+    $name.html(iName);
   });
 });
 


### PR DESCRIPTION
The video internationalize names prompts to create a function called inName with name as a parameter yet the script that calls it doesn't provide a name as an argument. This fixes the issue.
----
Pull name from DOM and call inName with name as argument