### PR TITLE
fix: map content overflowing on small viewports

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -207,8 +207,11 @@ span {
   margin: 0 5%;
 }
 
-#mapDiv {
+#map-container {
   height: 400px;
+}
+
+#mapDiv {
   width: 100%;
   padding-bottom: 5%;
 }

--- a/index.html
+++ b/index.html
@@ -57,8 +57,10 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
     <div id="education" class="gray">
       <h2>Education</h2>
     </div>
-    <div id="mapDiv">
-      <h2>Where I've Lived and Worked</h2>
+    <div id="map-container">
+      <div id="mapDiv">
+        <h2>Where I've Lived and Worked</h2>
+      </div>
     </div>
     <div id="lets-connect" class="dark-gray">
       <h2 class="orange center-text">Let's Connect</h2>


### PR DESCRIPTION
On small viewports (e.g., 320px, iPhone 5) the map was overflowing
and covering the "Let's Connect" message. Add container div for map
with height of 400px. Change height of mapDiv to default setting
(auto) to allow room on small viewports for header text and the map.
