### PR TITLE
Fix: using "flex-box" instead of "flex-column" in HTMLskillsStart

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,6 +130,11 @@ a {
 /* TODO: Replace with image later */
 #header {
   background-color: #484848;
+  padding-top: 0;
+}
+
+#topContacts {
+  padding-top: 0;
 }
 
 .flex-box {
@@ -173,6 +178,20 @@ span {
 
 #lets-connect {
   text-align: center;
+}
+
+button {
+  margin: 0 auto;
+}
+
+.button {
+  background: #ffffff;
+  border: 0;
+  padding: 3px, 6px;
+  font-weight: bold;
+  color: #f5ae23;
+  width: 10%;
+  margin-left: 45%;
 }
 
 /* Media queries to handle various device widths */

--- a/index.html
+++ b/index.html
@@ -23,9 +23,7 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
   <title>Resume</title>
 
   <!-- Load the page styles. -->
-  <link href="css/style.css" rel="stylesheet">
-
-
+  <link href="css/style.css" rel="stylesheet" type="text/css"></link>
 
   <!--
   Uncomment the <script> tag below when you're ready to add an interactive Google Map to your resume!
@@ -36,8 +34,6 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
 </head>
 <body>
   <div id="main">
-    Hello world!   <!-- You'll be deleting this line in the course -->
-
     <!--
     Everything from here to the <script> tag below is the skeleton of your
     website. Your code will add information to each of the sections of the
@@ -73,7 +69,7 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
    <!-- "Javascript assets, by default, tend to block any other parallel downloads from occurring. So, you can imagine if you have plenty of <script> tags in the head, calling on multiple external scripts will block the HTML from loading, thus greeting the user with a blank white screen, because no other content on your page will load until the JS files have completely loaded."
     http://stackoverflow.com/questions/4396849/does-the-script-tag-position-in-html-affects-performance-of-the-webpage -->
 
-    <!--
+  <!--
   jQuery is a common JavaScript library for reading and making changes to the
   Document Object Model (DOM). The DOM is a tree that contains information
   about what is actually visible on a website.
@@ -111,8 +107,6 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
     // Notice how all of a sudden there's JavaScript inside this HTML
     // document? You can write JavaScript between <script> tags. At the end of your
     // JavaScript, don't forget the closing script tag with the slash (/).
-
-
     // Also, this is a JavaScript style comment. You can comment in JavaScript with:
 
     //   two slashes for all following characters on a single line, or
@@ -120,26 +114,30 @@ need to load. You'll see a lot of <link>s to CSS files for styles and
     /*
         an opening and closing set of slash asterisks for block comments.
     */
-
-
     if(document.getElementsByClassName('flex-item').length === 0) {
       document.getElementById('topContacts').style.display = 'none';
     }
+
     if(document.getElementsByTagName('h1').length === 0) {
       document.getElementById('header').style.display = 'none';
     }
+
     if(document.getElementsByClassName('work-entry').length === 0) {
       document.getElementById('workExperience').style.display = 'none';
     }
+
     if(document.getElementsByClassName('project-entry').length === 0) {
       document.getElementById('projects').style.display = 'none';
     }
+
     if(document.getElementsByClassName('education-entry').length === 0) {
       document.getElementById('education').style.display = 'none';
     }
+
     if(document.getElementsByClassName('flex-item').length === 0) {
       document.getElementById('lets-connect').style.display = 'none';
     }
+
     if(document.getElementById('map') === null) {
       document.getElementById('mapDiv').style.display = 'none';
     }

--- a/js/helper.js
+++ b/js/helper.js
@@ -26,7 +26,7 @@ var HTMLlocation = '<li class="flex-item"><span class="orange-text">location</sp
 var HTMLbioPic = '<img src="%data%" class="biopic">';
 var HTMLwelcomeMsg = '<span class="welcome-message">%data%</span>';
 
-var HTMLskillsStart = '<h3 id="skills-h3">Skill Summary:</h3><ul id="skills" class="flex-box"></ul>';
+var HTMLskillsStart = '<h3 id="skills-h3">Skills Summary:</h3><ul id="skills" class="flex-box"></ul>';
 var HTMLskills = '<li class="flex-item"><span class="white-text">%data%</span></li>';
 
 var HTMLworkStart = '<div class="work-entry"></div>';
@@ -44,7 +44,7 @@ var HTMLprojectImage = '<img src="%data%">';
 
 var HTMLschoolStart = '<div class="education-entry"></div>';
 var HTMLschoolName = '<a href="#">%data%';
-var HTMLschoolDegree = ' -- %data%</a>';
+var HTMLschoolDegree = ' - %data%</a>';
 var HTMLschoolDates = '<div class="date-text">%data%</div>';
 var HTMLschoolLocation = '<div class="location-text">%data%</div>';
 var HTMLschoolMajor = '<em><br>Major: %data%</em>';
@@ -55,7 +55,7 @@ var HTMLonlineSchool = ' - %data%</a>';
 var HTMLonlineDates = '<div class="date-text">%data%</div>';
 var HTMLonlineURL = '<br><a href="#">%data%</a>';
 
-var internationalizeButton = '<button>Internationalize</button>';
+var internationalizeButton = '<button class="button">Internationalize</button>';
 var googleMap = '<div id="map"></div>';
 
 
@@ -86,7 +86,9 @@ function logClicks(x,y) {
 }
 
 $(document).click(function(loc) {
-  // your code goes here!
+  var x = loc.pageX;
+  var y = loc.pageY;
+  logClicks(x,y);
 });
 
 

--- a/js/helper.js
+++ b/js/helper.js
@@ -26,7 +26,7 @@ var HTMLlocation = '<li class="flex-item"><span class="orange-text">location</sp
 var HTMLbioPic = '<img src="%data%" class="biopic">';
 var HTMLwelcomeMsg = '<span class="welcome-message">%data%</span>';
 
-var HTMLskillsStart = '<h3 id="skills-h3">Skills at a Glance:</h3><ul id="skills" class="flex-column"></ul>';
+var HTMLskillsStart = '<h3 id="skills-h3">Skill Summary:</h3><ul id="skills" class="flex-box"></ul>';
 var HTMLskills = '<li class="flex-item"><span class="white-text">%data%</span></li>';
 
 var HTMLworkStart = '<div class="work-entry"></div>';

--- a/js/resumeBuilder.js
+++ b/js/resumeBuilder.js
@@ -1,3 +1,191 @@
-/*
-This is empty on purpose! Your code to build the resume will go here.
- */
+ var work = 
+ {
+ 	"jobs": [
+ 	{
+ 		"employer" : "Place Taker Company",
+ 		"title" : "web developer",
+ 		"location" : "The City",
+ 		"dates" : "2013 - Present",
+ 		"description" : "Full stack web development"
+ 	}],
+
+ 	// display function of work
+ 	display: function()
+ 	{
+ 		for (job in work.jobs)
+ 		{
+ 			$("#workExperience").append(HTMLworkStart);
+ 			$(".work-entry:last").append(HTMLworkEmployer.replace
+ 				("%data%", work.jobs[job].employer) + 
+ 				HTMLworkTitle.replace
+ 				("%data%", work.jobs[job].title));
+ 			$(".work-entry:last").append(HTMLworkDates.replace
+ 				("%data%", work.jobs[job].dates));
+ 			$(".work-entry:last").append(HTMLworkDescription.replace
+ 				("%data%", work.jobs[job].description));
+ 		}
+ 	}
+ };
+
+ var projects = 
+ {
+ 	"projects" : [
+ 	{
+ 		"title" : "Project A",
+ 		"dates" : "2013 - 2014",
+ 		"description" : "development of web applications: this is a sample description...",
+ 		"images" : ["images/197x148.gif", "images/197x148.gif", 
+ 					"images/197x148.gif", "images/197x148.gif",
+ 					"images/197x148.gif"]
+ 	},
+ 	{
+ 		"title" : "Project B",
+ 		"dates" : "2014 - 2016",
+ 		"description" : "development of web back end: this is another sample description...",
+ 		"images" : ["images/197x148.gif", "images/197x148.gif",
+ 					"images/197x148.gif", "images/197x148.gif",
+ 					"images/197x148.gif"]
+ 	}],
+
+ 	// display function of projects
+ 	display: function()
+ 	{
+ 		projects.projects.forEach(function(element)
+ 		{
+ 			$("#projects").append(HTMLprojectStart);
+ 			$(".project-entry:last").append(HTMLprojectTitle.replace("%data%", element.title));
+ 			$(".project-entry:last").append(HTMLprojectDates.replace("%data%", element.dates));
+ 			$(".project-entry:last").append(HTMLprojectDescription.replace("%data%", element.description));
+ 			if (element.images.length > 0)
+ 			{
+ 				for (image in element.images)
+ 				{
+ 					$(".project-entry:last").append(HTMLprojectImage.replace("%data%", element.images[image]));
+ 				}
+ 			}
+ 	    })
+ 	}
+ };
+
+ var bio = 
+ {
+ 	"name" : "John Doe",
+ 	"role" : "Full Stack Web Developer",
+ 	"contacts" : 
+ 	{
+ 		"mobile" : "111-222-3456",
+ 		"email" : "john.doe@gmail.com",
+ 		"github" : "JohnDoe",
+ 		"twitter" : "@JohnDoe",
+ 		"location" : " City"
+ 	},
+ 	"welcomeMessage" : "Hello! Welcome to John Doe's resume page! This is a sample message...",
+ 	"skills" : ["Python", "Java", "JavaScript", "HTML", 
+ 	            "CSS", "JSON", "mySQL", "markdown"],
+ 	"bioPic" : "images/fry.jpg",
+
+ 	// display function of biography.
+ 	display: function()
+ 	{
+ 		// Banner information
+		$("#header").prepend(HTMLheaderRole.replace("%data%", bio.role));
+		$("#header").prepend(HTMLheaderName.replace("%data%", bio.name));
+		$("#main").append(internationalizeButton);
+		
+		// Header - Contact Information
+		$("#topContacts").append(HTMLmobile.replace("%data%", bio.contacts.mobile));
+		$("#topContacts").append(HTMLemail.replace("%data%", bio.contacts.email));
+		$("#topContacts").append(HTMLgithub.replace("%data%", bio.contacts.github));
+		$("#topContacts").append(HTMLtwitter.replace("%data%", bio.contacts.twitter));
+		$("#topContacts").append(HTMLlocation.replace("%data%", bio.contacts.location));
+
+		// Header - Other Parts
+		$("#header").append(HTMLbioPic.replace("%data%", bio.bioPic));
+		$("#header").append(HTMLwelcomeMsg.replace("%data%", bio.welcomeMessage));
+
+		// Header - Skills
+		$("#header").append(HTMLskillsStart);
+		bio.skills.forEach(function(element)
+		{
+			$("#skills").append(HTMLskills.replace("%data%", element));
+		}); 
+ 	}
+ };
+
+ var education =
+ {
+ 	"schools":[{
+ 		"name" : "Sample University",
+		"location" : "Another City",
+		"degree" : "Bachelor of Science",
+		"majors" : ["Computer Science"],
+		"dates" : "2014",
+		"url" : "www.sample.edu"
+		
+	}],
+ 	"onlineCourses":[{
+		"title" : "Basic JavaScript",
+		"school" : "Udacity",
+		"dates" : "2014.7",
+		"url" : "www.udacity.com"
+	}],
+
+	// display function of eduction
+	display: function()
+	{
+		for (element in education.schools)
+		{
+			$("#education").append(HTMLschoolStart);
+			$(".education-entry:last").append(HTMLschoolName.replace
+				("%data%", education.schools[element].name) + 
+				HTMLschoolDegree.replace
+				("%data%", education.schools[element].degree));
+			$(".education-entry:last").append(HTMLschoolDates.replace
+				("%data%", education.schools[element].dates));
+			$(".education-entry:last").append(HTMLschoolLocation.replace
+				("%data%", education.schools[element].location));
+
+		    for (major in education.schools[element].majors)
+		    {
+		    	$(".education-entry:last").append(HTMLschoolMajor.replace
+					("%data%", education.schools[element].majors[major]));
+		    }
+		}
+
+		$("#education").append(HTMLonlineClasses);
+
+		for (element in education.onlineCourses)
+		{
+			$("#education").append(HTMLschoolStart);
+			$(".education-entry:last").append
+				(HTMLonlineTitle.replace
+					("%data%", education.onlineCourses[element].title) +
+				HTMLonlineSchool.replace
+					("%data%", education.onlineCourses[element].school));
+		    $(".education-entry:last").append
+				(HTMLonlineDates.replace
+					("%data%", education.onlineCourses[element].dates));
+		    $(".education-entry:last").append
+				(HTMLonlineURL.replace
+					("%data%", education.onlineCourses[element].url));			
+		}
+	}
+ };
+
+ // Display all of the sections
+
+ bio.display();
+ work.display();
+ projects.display();
+ education.display();
+
+ // helper function to convert name into international format
+ function inName()
+ {
+ 	var name = bio.name.split(" ");
+ 	var first_name = name[0].substr(0,1).toUpperCase() + 
+ 					 name[0].substr(1).toLowerCase();
+ 	var last_name = name[1].toUpperCase();
+ 	return first_name + ' ' + last_name;
+ }
+ 


### PR DESCRIPTION
  I've noticed that `HTMLskillsStart` is initialized as class `flex-cloumn` in **helper.js**:
```
var HTMLskillsStart = '<h3 id="skills-h3">Skill Summary:</h3><ul id="skills" class="flex-cloumn"></ul>';
```
In this case, all the skills listed in this section will not be aligned in a roll as shown in the Udacity video. Using `flex-box` instead is able to keep the output same as shown in the class video, and thus avoid possible confusion in studying. 

```
var HTMLskillsStart = '<h3 id="skills-h3">Skill Summary:</h3><ul id="skills" class="flex-box"></ul>';
```